### PR TITLE
Allow minting multiple editions with the same set/play but different tiers

### DIFF
--- a/lib/go/test/allday_test.go
+++ b/lib/go/test/allday_test.go
@@ -390,19 +390,16 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 		)
 	})
 
-	t.Run("Should not be able to create an Edition with a Set/Play combination that already exists", func(t *testing.T) {
-		testCreateEdition(
-			t,
-			b,
-			contracts,
-			1,
-			1,
-			2,
-			nil,
-			"COMMON",
-			5,
-			true,
-		)
+	t.Run("Should be able to create an Edition with a Set/Play combination that already exists but with a different tier", func(t *testing.T) {
+		//Mint LEGENDARY edition
+		testCreateEdition(t, b, contracts, 1 /*seriesID*/, 1 /*setID*/, 2 /*playID*/, nil,
+			"LEGENDARY" /*tier*/, 4 /*shouldBEID*/, false /*shouldRevert*/)
+	})
+
+	t.Run("Should NOT be able to mint new edition using the same set/play with new tier", func(t *testing.T) {
+		//Mint COMMON edition again, tx should revert
+		testCreateEdition(t, b, contracts, 1 /*seriesID*/, 1 /*setID*/, 2 /*playID*/, nil,
+			"COMMON" /*tier*/, 5 /*shouldBEID*/, true /*shouldRevert*/)
 	})
 
 	t.Run("Should be able to close and edition that has no max mint size", func(t *testing.T) {


### PR DESCRIPTION
Allow minting multiple editions with the same set/play but different tiers. This would eliminate the need to create redundant play data for cases when we create dynamic moments/editions for multiple tiers.
- Removing the mint edition pre-condition check that prevent a new edition with the same setID and playID from being created
- Use a map to keep track of existing setID + playID + tier combination to prevent duplication. The map is store in the minter account's storage. Will manually backfill the map for existing editions.