### PR TITLE
Sadie/deserialized editions

### DIFF
--- a/lib/go/test/allday_test.go
+++ b/lib/go/test/allday_test.go
@@ -1,9 +1,10 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/fixedpoint"
-	"testing"
 
 	emulator "github.com/onflow/flow-emulator"
 	"github.com/onflow/flow-go-sdk"
@@ -274,6 +275,8 @@ func testCreateEdition(
 	playID uint64,
 	maxMintSize *uint64,
 	tier string,
+	deserialized *bool,
+	presetSerial *uint64,
 	shouldBeID uint64,
 	shouldRevert bool,
 ) {
@@ -286,6 +289,8 @@ func testCreateEdition(
 		playID,
 		maxMintSize,
 		tier,
+		deserialized,
+		presetSerial,
 		shouldRevert,
 	)
 
@@ -298,6 +303,12 @@ func testCreateEdition(
 		assert.Equal(t, tier, edition.Tier)
 		if maxMintSize != nil {
 			assert.Equal(t, &maxMintSize, &edition.MaxMintSize)
+		}
+		if deserialized != nil {
+			assert.Equal(t, &deserialized, &edition.Deserialized)
+		}
+		if presetSerial != nil {
+			assert.Equal(t, &presetSerial, &edition.PresetSerial)
 		}
 	}
 }
@@ -326,6 +337,8 @@ func testCloseEdition(
 
 func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contracts) {
 	var maxMintSize uint64 = 2
+	var deserialized bool = true
+	var presetSerial uint64 = 2023
 	createTestSeries(t, b, contracts)
 	createTestSets(t, b, contracts)
 	createTestPlays(t, b, contracts)
@@ -340,6 +353,8 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 			1,
 			&maxMintSize,
 			"COMMON",
+			nil,
+			nil,
 			1,
 			false,
 		)
@@ -355,6 +370,8 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 			1,
 			nil,
 			"COMMON",
+			nil,
+			nil,
 			2,
 			false,
 		)
@@ -370,6 +387,8 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 			2,
 			nil,
 			"COMMON",
+			nil,
+			nil,
 			3,
 			false,
 		)
@@ -385,6 +404,8 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 			1,
 			nil,
 			"COMMON",
+			nil,
+			nil,
 			4,
 			true,
 		)
@@ -393,13 +414,13 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 	t.Run("Should be able to create an Edition with a Set/Play combination that already exists but with a different tier", func(t *testing.T) {
 		//Mint LEGENDARY edition
 		testCreateEdition(t, b, contracts, 1 /*seriesID*/, 1 /*setID*/, 2 /*playID*/, nil,
-			"LEGENDARY" /*tier*/, 4 /*shouldBEID*/, false /*shouldRevert*/)
+			"LEGENDARY" /*tier*/, nil /*deserialized*/, nil /*presetSerial*/, 4 /*shouldBEID*/, false /*shouldRevert*/)
 	})
 
 	t.Run("Should NOT be able to mint new edition using the same set/play with new tier", func(t *testing.T) {
 		//Mint COMMON edition again, tx should revert
 		testCreateEdition(t, b, contracts, 1 /*seriesID*/, 1 /*setID*/, 2 /*playID*/, nil,
-			"COMMON" /*tier*/, 5 /*shouldBEID*/, true /*shouldRevert*/)
+			"COMMON" /*tier*/, nil /*deserialized*/, nil /*presetSerial*/, 5 /*shouldBEID*/, true /*shouldRevert*/)
 	})
 
 	t.Run("Should be able to close and edition that has no max mint size", func(t *testing.T) {
@@ -410,6 +431,23 @@ func createTestEditions(t *testing.T, b *emulator.Blockchain, contracts Contract
 			3,
 			3,
 			false,
+		)
+	})
+
+	t.Run("Should be able to create a deserialized edition and set the serial number", func(t *testing.T) {
+		testCreateEdition(
+			t,
+			b,
+			contracts,
+			1,
+			1,
+			1,
+			nil,
+			"COMMON",
+			&deserialized,
+			&presetSerial,
+			5,
+			true,
 		)
 	})
 }

--- a/lib/go/test/transactions.go
+++ b/lib/go/test/transactions.go
@@ -1,8 +1,9 @@
 package test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
 	emulator "github.com/onflow/flow-emulator"
@@ -237,6 +238,8 @@ func createEdition(
 	playID uint64,
 	maxMintSize *uint64,
 	tier string,
+	deserialized *bool,
+	presetSerial *uint64,
 	shouldRevert bool,
 ) {
 	tierString, _ := cadence.NewString(tier)
@@ -256,6 +259,17 @@ func createEdition(
 		tx.AddArgument(cadence.Optional{})
 	}
 
+	if deserialized != nil {
+		tx.AddArgument(cadence.NewBool(*deserialized))
+	} else {
+		tx.AddArgument(cadence.Optional{})
+	}
+
+	if presetSerial != nil {
+		tx.AddArgument(cadence.NewUInt64(*presetSerial))
+	} else {
+		tx.AddArgument(cadence.Optional{})
+	}
 	signer, err := b.ServiceKey().Signer()
 	require.NoError(t, err)
 	signAndSubmit(

--- a/lib/go/test/types.go
+++ b/lib/go/test/types.go
@@ -19,12 +19,14 @@ type PlayData struct {
 	Metadata       map[string]string
 }
 type EditionData struct {
-	ID          uint64
-	SeriesID    uint64
-	SetID       uint64
-	PlayID      uint64
-	MaxMintSize *uint64
-	Tier        string
+	ID           uint64
+	SeriesID     uint64
+	SetID        uint64
+	PlayID       uint64
+	MaxMintSize  *uint64
+	Tier         string
+	Deserialized *bool
+	PresetSerial *uint64
 }
 type OurNFTData struct {
 	ID           uint64
@@ -74,6 +76,16 @@ func parseEditionData(value cadence.Value) EditionData {
 	if fields[4] != nil && fields[4].ToGoValue() != nil {
 		maxMintSize = fields[4].ToGoValue().(uint64)
 	}
+
+	var deserialized bool
+	if fields[7] != nil && fields[7].ToGoValue() != nil {
+		deserialized = fields[7].ToGoValue().(bool)
+	}
+
+	var presetSerial uint64
+	if fields[8] != nil && fields[8].ToGoValue() != nil {
+		presetSerial = fields[8].ToGoValue().(uint64)
+	}
 	return EditionData{
 		fields[0].ToGoValue().(uint64),
 		fields[1].ToGoValue().(uint64),
@@ -81,6 +93,8 @@ func parseEditionData(value cadence.Value) EditionData {
 		fields[3].ToGoValue().(uint64),
 		&maxMintSize,
 		fields[5].ToGoValue().(string),
+		&deserialized,
+		&presetSerial,
 	}
 }
 

--- a/transactions/admin/editions/create_edition.cdc
+++ b/transactions/admin/editions/create_edition.cdc
@@ -6,6 +6,8 @@ transaction(
     playID: UInt64,
     tier: String,
     maxMintSize: UInt64?,
+    deserialized: Bool?,
+    presetSerial: UInt64?,
    ) {
     // local variable for the admin reference
     let admin: &AllDay.Admin
@@ -23,6 +25,8 @@ transaction(
             playID: playID,
             maxMintSize: maxMintSize,
             tier: tier,
+            deserialized: deserialized,
+            presetSerial: presetSerial,
         )
 
         log("====================================")


### PR DESCRIPTION
This PR makes the following adjustments to the NFL AllDay smart contract:
- Adds a new optional field - `deserialized` to an Edition
- Adds a new optional field - `presetSerial` to an Edition
- Validates that if `deserialized` is true, `presetSerial` must be set
- Adds the `deserialized` field to an EditionCreated event
- If the moment is `deserialized`, the `presetSerial` number will be used as the serial for each Moment NFT that is minted


- For @maddenwalker and @Deewai 